### PR TITLE
Add "check" to dependencies

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,6 +12,7 @@ Package.on_use(function (api) {
   api.versionsFrom("METEOR-CORE@0.9.0-atm");
   api.use("infinitedg:winston@0.7.3", 'server');
   api.use('meteor', 'server');
+  api.use('check', 'server');
   api.add_files('client.js', 'client');
     if (api.export) {
         api.export("Winston", 'client');


### PR DESCRIPTION
This project depends on check. To use winston-client I had to manually add check to the package.js file to make it work.
Adding this line fixes the problem.
