### PR TITLE
pass the level parameter only once in the .log()

### DIFF
--- a/client.js
+++ b/client.js
@@ -14,7 +14,7 @@ var log = function(level, args) {
 }
 
 Winston = {
-  log:      function(level) { log(level, arguments)},
+  log:      function(level) { log(level, Array.prototype.slice.call(arguments, 1)); },
   silly:    function() { log('silly', arguments); },
   input:    function() { log('input', arguments); },
   verbose:  function() { log('verbose', arguments); },


### PR DESCRIPTION
The level parameter is currently passed separately and with the "arguments" object.

example:
Winston.log("info", "test");
This results in console output like this:
info: info test
